### PR TITLE
Add french documentation and inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Formation CDA 2025
+
+Ce dépôt illustre un petit service Node.js utilisant **Express** et **Mongoose**. Il expose un service de gestion d'utilisateurs ainsi qu'une suite de tests unitaires.
+
+## Installation
+
+```bash
+npm install
+```
+
+Une base MongoDB doit être accessible. L'URL de connexion est définie dans `config.js`.
+
+## Lancement du serveur
+
+```bash
+node server.js
+```
+
+## Lancement des tests
+
+```bash
+npm test
+```
+
+## Structure du projet
+
+- `server.js` : point d'entrée de l'application Express.
+- `config.js` : configuration (URL Mongo).
+- `schemas/` : schémas Mongoose (ex. `User.js`).
+- `services/` : logique métier (CRUD sur les utilisateurs).
+- `utils/` : outils divers comme la gestion d'erreurs.
+- `test/` : suite de tests Mocha.
+
+Chaque fichier source a été abondamment commenté pour faciliter la compréhension du code et des différentes étapes.

--- a/config.js
+++ b/config.js
@@ -1,3 +1,5 @@
+// Configuration de l'application
 module.exports = {
+    // URL de connexion à MongoDB utilisée par les services
     mongo_url: 'mongodb://192.168.147.40/testing_formation',
 }

--- a/schemas/User.js
+++ b/schemas/User.js
@@ -1,30 +1,36 @@
-const mongoose = require('mongoose')
+const mongoose = require('mongoose') // Importe mongoose
 
+// Schéma de l'utilisateur
 const UserSchema = new mongoose.Schema({
+  // Nom d'utilisateur unique et obligatoire
   username: {
     type: String,
     index: true,
     unique: true,
     required: true
   },
+  // Adresse mail de l'utilisateur
   email: {
     type: String,
     required: true
   },
+  // Mot de passe en clair (pour exemple uniquement)
   password: {
     type: String,
     required: true
   },
+  // Code de statut de l'utilisateur (actif/inactif etc.)
   status_code: {
     type: Number,
     required: true,
     default: 1
   },
+  // Date de création du compte
   createdAt: {
     type: Date,
     required: true,
     default: new Date()
   },
-});
+})
 
-module.exports = UserSchema
+module.exports = UserSchema // Exporte le schéma pour création du modèle

--- a/server.js
+++ b/server.js
@@ -1,23 +1,22 @@
-const express = require('express')
-const app = express()
-const port = 3000
-
+const express = require('express') // Importe le framework Express
+const app = express() // Initialise l'application Express
+const port = 3000 // Port d'écoute du serveur
 
 // getting-started.js
-const mongoose = require('mongoose');
+const mongoose = require('mongoose') // Importe Mongoose pour communiquer avec MongoDB
 
-main().catch(err => console.log(err));
+main().catch(err => console.log(err)) // Lance la connexion à Mongo et log l'erreur si besoin
 
-async function main() {
-  await mongoose.connect('mongodb://127.0.0.1:27017/test');
+async function main () {
+  await mongoose.connect('mongodb://127.0.0.1:27017/test') // Connexion à la base locale
 
-  // use `await mongoose.connect('mongodb://user:password@127.0.0.1:27017/test');` if your database has auth enabled
+  // Utiliser `await mongoose.connect('mongodb://user:password@127.0.0.1:27017/test');` si votre base nécessite une authentification
 }
 
-app.get('/', (req, res) => {
-  res.send('Hello World!')
+app.get('/', (req, res) => { // Route GET basique
+  res.send('Hello World!') // Réponse simple en texte
 })
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
+app.listen(port, () => { // Démarrage du serveur HTTP
+  console.log(`Example app listening on port ${port}`) // Affiche un message au démarrage
 })

--- a/services/UserService.js
+++ b/services/UserService.js
@@ -1,34 +1,42 @@
-const mongoose = require('mongoose')
-const UserSchema = require('../schemas/User')
+const mongoose = require('mongoose') // Importe mongoose
+const UserSchema = require('../schemas/User') // Schéma utilisateur
 
-const User = mongoose.model('User', UserSchema);
+const User = mongoose.model('User', UserSchema) // Création du modèle User
 
+const ErrorManager = require('../utils/error') // Gestionnaire d'erreurs personnalisé
 
-
-const ErrorManager = require('../utils/error')
-
-/* 
-    - Créer un element
-    - Modifier un element
-    - Recuperer un element
-    - Supprimer un element
+/*
+    Fonctions CRUD utilisées dans les tests
+    - Créer un élément
+    - Modifier un élément
+    - Récupérer un élément
+    - Supprimer un élément
 */
 
+/**
+ * Ajoute un utilisateur en base
+ * @param {Object} payload Données du nouvel utilisateur
+ * @param {Object|null} options Options diverses
+ */
 module.exports.addOneUser = async function (payload, options = null) {
     try {
-        var newUser = new User(payload)
-        let save = await newUser.save()
+        var newUser = new User(payload) // Création d'une instance du modèle
+        let save = await newUser.save() // Sauvegarde en base
         return save
     }
     catch (err) {
-        throw (ErrorManager.parsingError(err))
+        throw (ErrorManager.parsingError(err)) // Normalisation de l'erreur
     }
 }
 
+/**
+ * Recherche un utilisateur par identifiant
+ */
 module.exports.findOneUserById = async function (id, options = null) {
     try {
-        let val = await User.findById(id)
+        let val = await User.findById(id) // Cherche l'utilisateur
         if (options && options.error_not_found && !val) {
+            // Erreur personnalisée si demandé
             throw { type: 'NOT_FOUND', message: 'Element non trouvé.' }
         }
         return val
@@ -38,10 +46,14 @@ module.exports.findOneUserById = async function (id, options = null) {
     }
 }
 
+/**
+ * Met à jour un utilisateur via son identifiant
+ */
 module.exports.updateOneUserById = async function (id, update, options = null) {
     try {
-        let val = await User.findByIdAndUpdate(id, update, {returnDocument: 'after', runValidators: true})
+        let val = await User.findByIdAndUpdate(id, update, { returnDocument: 'after', runValidators: true }) // Mise à jour
         if (options && options.error_not_found && !val) {
+            // Lance une erreur si demandé et que l'utilisateur n'existe pas
             throw { type: 'NOT_FOUND', message: 'Element non trouvé.' }
         }
         return val
@@ -52,9 +64,12 @@ module.exports.updateOneUserById = async function (id, update, options = null) {
 }
 
 
+/**
+ * Supprime un utilisateur
+ */
 module.exports.deleteOneUserById = async function (id, options = null) {
     try {
-        let val = await User.findByIdAndDelete(id)
+        let val = await User.findByIdAndDelete(id) // Suppression directe
         if (options && options.error_not_found && !val) {
             throw { type: 'NOT_FOUND', message: 'Element non trouvé.' }
         }

--- a/utils/error.js
+++ b/utils/error.js
@@ -1,26 +1,31 @@
-const mongoose = require('mongoose')
+const mongoose = require('mongoose') // Importe mongoose pour identifier les erreurs
 
+// Formate les erreurs de validation de champs mongoose
 let createValidationFieldsError = function (error, options) {
-    let keys_error = Object.keys(error.errors)
-    let error_formated = error.errors
-    let object_error = {}
+    let keys_error = Object.keys(error.errors) // Récupère les noms des champs en erreur
+    let error_formated = error.errors // Accès direct aux informations d'erreur
+    let object_error = {} // Objet contenant le détail des erreurs
     keys_error.forEach((element) => {
-        object_error[element] = error_formated[element].message
+        object_error[element] = error_formated[element].message // Copie le message associé à chaque champ
     })
     return object_error
 }
 
 
+// Normalise les différents types d'erreurs mongoose en un format commun
 let pasingMongooseError = function (error, options) {
     if (error instanceof mongoose.Error.ValidationError) {
+        // Erreur de validation : on renvoie le détail des champs invalides
         var field_errors = createValidationFieldsError(error, options)
         return { type: 'NOT_VALID', message: 'Le schéma est incorrect.', fields: field_errors }
         /*  {fields: { <champs en erreur>: 'Le champs est requis' }}  */
     }
     else if (error && error.code == 11000) {
+        // Doublon d'un champ unique
         return { type: 'DUPLICATE', message: "Un champs n'est pas unique.", fields: error.keyValue }
     }
     else if (error instanceof mongoose.Error.CastError) {
+        // Problème de conversion d'un champ (ex: ObjectId invalide)
         return { type: 'NOT_VALID_CAST', message: 'Un champ ne dispose pas du bon format.', fields: {[error.path]: error.reason.message} }
     }
     console.log("Cas d'erreur mongoose non gerer non gérer")
@@ -28,8 +33,10 @@ let pasingMongooseError = function (error, options) {
 }
 
 
+// Point d'entrée pour parser toutes les erreurs métiers
 module.exports.parsingError = function (error, options) {
     if ((error instanceof mongoose.Error) || (error && error.code == 11000)) {
+        // Si l'erreur vient de mongoose, on la normalise
         return pasingMongooseError(error, options)
     }
     console.log("Cas d'erreur non gérer")


### PR DESCRIPTION
## Summary
- add README in French with project usage instructions
- document config file and server entry point
- add explanations to mongoose schema
- comment all user service functions
- improve error helper with comments

## Testing
- `npm test` *(fails: connect ENETUNREACH 192.168.147.40:27017)*

------
https://chatgpt.com/codex/tasks/task_e_686cfd3cae50832f8c76d25316b5ba85